### PR TITLE
Fix issue with failure to load on cache clear command

### DIFF
--- a/lib/AbstractMultiBundle.php
+++ b/lib/AbstractMultiBundle.php
@@ -12,11 +12,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 abstract class AbstractMultiBundle extends Bundle
 {
     /**
-     * @var bool[]
-     */
-    private static $_hasRegisteredSelfFlags = array();
-
-    /**
      * Register this bundle collection into the Symfony kernel, e.g.
      *
      * <code>

--- a/lib/AbstractMultiBundle.php
+++ b/lib/AbstractMultiBundle.php
@@ -74,10 +74,7 @@ abstract class AbstractMultiBundle extends Bundle
         }
 
         // Register myself
-        if ( ! isset(self::$_hasRegisteredSelfFlags[$calledClass])) {
-            $dependencies[] = new $calledClass();
-            self::$_hasRegisteredSelfFlags[$calledClass] = true;
-        }
+        $dependencies[] = new $calledClass();
 
         // Remove duplicates
         foreach ($bundles as $bundle) {

--- a/tests/AbstractMultiBundleTest.php
+++ b/tests/AbstractMultiBundleTest.php
@@ -190,11 +190,13 @@ class AbstractMultiBundleTest extends \PHPUnit_Framework_TestCase
         $this->_assertInstanceInArray('AshleyDawson\MultiBundle\Tests\Fixture\DummyBundleTwo', $bundles);
         $this->_assertInstanceInArray('AshleyDawson\MultiBundle\Tests\DummyParentGroupedDependantsBundle', $bundles);
 
-        $bundles = array();
+        $bundles = array_filter($bundles, function($bundle){
+            return ($bundle instanceof DummyParentGroupedDependantsBundle);
+        });
 
         DummyParentGroupedDependantsBundle::registerInto($bundles, 'dev');
 
-        $this->assertCount(1, $bundles);
+        $this->assertCount(2, $bundles);
 
         $this->_assertInstanceInArray('AshleyDawson\MultiBundle\Tests\Fixture\DummyBundleThree', $bundles);
     }


### PR DESCRIPTION
Hi there,
Thanks for the useful library.  Has just come in handy on a project, but I did have a problem with the bundle load failing when running the `app/console clear:cache` command, which was actually calling registerBundles() twice.
For the second call, the bundle believed it had already been registered, so wasn't re-registering te second time around, and therefore not available to parse config values.
As the duplicate bundles are removed at the end of the registerInto() method, there's no real harm in checking if it's already been registered, is there?
I've also update the testRegisterIntoGroupedDependantsNoPrevious() unit test to reflect the change.
Hope you find this useful.
Toby
